### PR TITLE
Import ChangeEvent type directly from React in DataTab component

### DIFF
--- a/app/components/@settings/tabs/data/DataTab.tsx
+++ b/app/components/@settings/tabs/data/DataTab.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useCallback, useEffect } from 'react';
+import { useState, useRef, useCallback, useEffect, type ChangeEvent } from 'react';
 import { Button } from '~/components/ui/Button';
 import { ConfirmationDialog, SelectionDialog } from '~/components/ui/Dialog';
 import { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter } from '~/components/ui/Card';
@@ -167,7 +167,7 @@ export function DataTab() {
 
   // Handle file input changes
   const handleFileInputChange = useCallback(
-    (event: React.ChangeEvent<HTMLInputElement>) => {
+    (event: ChangeEvent<HTMLInputElement>) => {
       const file = event.target.files?.[0];
 
       if (file) {
@@ -178,7 +178,7 @@ export function DataTab() {
   );
 
   const handleAPIKeyFileInputChange = useCallback(
-    (event: React.ChangeEvent<HTMLInputElement>) => {
+    (event: ChangeEvent<HTMLInputElement>) => {
       const file = event.target.files?.[0];
 
       if (file) {
@@ -190,7 +190,7 @@ export function DataTab() {
   );
 
   const handleChatFileInputChange = useCallback(
-    (event: React.ChangeEvent<HTMLInputElement>) => {
+    (event: ChangeEvent<HTMLInputElement>) => {
       const file = event.target.files?.[0];
 
       if (file) {


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Import `ChangeEvent` type directly from React

- Replace `React.ChangeEvent` with `ChangeEvent` in event handlers

- Simplify type imports in DataTab component


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["React import"] --> B["Add ChangeEvent type"]
  B --> C["Update event handlers"]
  C --> D["Cleaner type usage"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DataTab.tsx</strong><dd><code>Import and use ChangeEvent type directly</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/components/@settings/tabs/data/DataTab.tsx

<ul><li>Added <code>ChangeEvent</code> type to React import statement<br> <li> Updated three event handler functions to use <code>ChangeEvent</code> instead of <br><code>React.ChangeEvent</code><br> <li> Simplified type annotations for file input change handlers</ul>


</details>


  </td>
  <td><a href="https://github.com/jamiegee1234/bolt.diy/pull/2/files#diff-baddab5cfc425ae41712da6700c1e818faced1b5bfd0d9f324bf1b051f8cc7f9">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

